### PR TITLE
Update json gem for CVE-2020-10663

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
       multi_json (>= 1.0.0)
       signet (~> 0.4.5)
       uuidtools (>= 2.1.0)
-    json (1.8.0)
+    json (2.3.1)
     jwt (0.1.8)
       multi_json (>= 1.5)
     launchy (2.3.0)
@@ -39,3 +39,6 @@ PLATFORMS
 DEPENDENCIES
   google-api-client
   json
+
+BUNDLED WITH
+   2.1.4


### PR DESCRIPTION
**Just to shut up Dependabot**

CVE-2020-10663
moderate severity
Vulnerable versions: < 2.3.0
Patched version: 2.3.0

The JSON gem through 2.2.0 for Ruby, as used in Ruby 2.4 through 2.4.9, 2.5 through 2.5.7, and 2.6 through 2.6.5, has an Unsafe Object Creation Vulnerability. This is quite similar to CVE-2013-0269/GHSA-x457-cw4h-hq5f, but does not rely on poor garbage-collection behavior within Ruby. Specifically, use of JSON parsing methods can lead to creation of a malicious object within the interpreter, with adverse effects that are application-dependent.